### PR TITLE
feat: ユーザーの継続期間を取得するAPIエンドポイントを追加

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
     "start": "node dist/app.js",
     "dev": " nodemon --legacy-watch --exec ts-node src/app.ts",
     "build": "tsc",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "seed": "ts-node src/scripts/seed.ts"
   },
   "dependencies": {
     "body-parser": "^1.20.3",

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,10 +1,27 @@
-import express, { Request, Response } from 'express';
+import express, { Request, Response, Router } from 'express';
+import { getDb } from '../db';
 
-const router = express.Router();
+const router: Router = express.Router();
 
 // ユーザーの現在の継続期間
-router.get('/:userId/stats/current-streak', (req: Request, res: Response) => {
-  res.send('Hello World');
+router.get('/:userId/stats/current-streak', async (req: Request, res: Response) => {
+  try {
+    const userId = req.params.userId;
+    const db = await getDb();
+    const streak: {current_streak: number} | undefined = await db.get<{current_streak: number}>(
+      'SELECT current_streak FROM users WHERE id = ?',
+      userId
+    );
+
+    if (streak === undefined) {
+      res.status(404).json({ error: 'user not found' });
+    }
+
+    res.json(streak);
+  } catch (error) {
+    console.error('Error getting streak:', error);
+    res.status(500).json({ error: 'server error' });
+  }
 });
 
 // ユーザーの現在の非継続期間


### PR DESCRIPTION
- package.jsonにシードスクリプトのコマンドを追加
- ユーザーの現在の継続期間を取得するGETエンドポイントを実装
- エラーハンドリングを追加し、ユーザーが見つからない場合のレスポンスを定義
